### PR TITLE
[FIX] fix endless csv discovering by modifying the shutdown detection 

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,13 +1,8 @@
 package cmd
 
 import (
-	"os"
-	"os/signal"
-	"syscall"
-
 	"github.com/cortze/ragno/crawler"
 
-	log "github.com/sirupsen/logrus"
 	cli "github.com/urfave/cli/v2"
 
 	"github.com/pkg/errors"
@@ -31,8 +26,8 @@ var RunCommand = &cli.Command{
 			DefaultText: crawler.DefaultDBEndpoint,
 		},
 		&cli.IntFlag{
-			Name: "disc-port",
-			Usage: "port that the tool will use for discovery purposes",
+			Name:    "disc-port",
+			Usage:   "port that the tool will use for discovery purposes",
 			Aliases: []string{"dp"},
 			EnvVars: []string{"RAGNO_PORT"},
 		},
@@ -104,20 +99,10 @@ func RunRagno(ctx *cli.Context) error {
 		return errors.Wrap(err, "error initializing the crawler")
 	}
 
-	// wait untill the process is stoped to close it down
-	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM, os.Interrupt, syscall.SIGTERM)
-
 	// start the crawler
-	err = ragno.Run()
-	if err != nil {
-		return errors.Wrap(err, "error running the crawler")
-	}
+	ragno.Run()
 
-	// run untill we receive the shutdown
-	sig := <-sigs
-	log.Infof("Received %s signal - Stopping Ragno with control...\n", sig.String())
-
+	// close the crawler
 	ragno.Close()
 
 	return nil


### PR DESCRIPTION
**Motivation**:
When using the csv discoverer, once all the nodes inside of the file would be send to the dialers the crawler would keep running infinitely

Also if a shutdown was done, the crawler wouldn't wait for the current node connection or the one being saved in the db

**Goals**:
- Detect when all the nodes of the csv have been sent to the dialers and wait until all the connection and saving processes are done before closing the crawler
- If a shutdown is detected when the crawler is running, it should wait for the current connections and saving to be done before stoping the crawler

**Done:**
- Move the signal detection in order to catch the shutdown in different places
- Use closing channels in order to detect when all the peers have been sent to the dialers
- Use waitgroups in order to wait for the different running parts of the crawler and shut them down in the right order