### PR TITLE
Tune deprecation system

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -16,3 +16,4 @@ METRICS_PORT=5080
 DIALERS=500
 SNAPSHOT_INTERVAL="12h"
 IP_API_URL="http://ip-api.com/json/{__ip__}?fields=status,continent,continentCode,country,countryCode,region,regionName,city,zip,lat,lon,isp,org,as,asname,mobile,proxy,hosting,query"
+DEPRECATION_TIME="48h"

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -87,6 +87,12 @@ var RunCommand = &cli.Command{
 			Aliases: []string{"ipapi"},
 			EnvVars: []string{"IP_API_URL"},
 		},
+		&cli.StringFlag{
+			Name:    "deprecation-time",
+			Usage:   "Time threshold for deprecating a node if no connection attempts were succesful",
+			Aliases: []string{"dt"},
+			EnvVars: []string{"DEPRECATION_TIME"},
+		},
 	},
 }
 

--- a/crawler/config.go
+++ b/crawler/config.go
@@ -10,11 +10,11 @@ import (
 var (
 	// crawler host related metrics
 	DefaultLogLevel             = "info"
-	DefaultDBEndpoint           = "postgresql://user:password@localhost:5440/ragnodb?sslmode=disable"
+	DefaultDBEndpoint           = "postgresql://user:password@localhost:5432/ragnodb"
 	DefaultHostIP               = "0.0.0.0"
-	DefaultHostPort             = 9051
+	DefaultHostPort             = 9050
 	DefaultMetricsIP            = "localhost"
-	DefaultMetricsPort          = 9071
+	DefaultMetricsPort          = 9070
 	DefaultMetricsEndpoint      = "metrics"
 	DefaultConcurrentDialers    = 150
 	DefaultConcurrentPersisters = 2

--- a/crawler/config.go
+++ b/crawler/config.go
@@ -10,17 +10,18 @@ import (
 var (
 	// crawler host related metrics
 	DefaultLogLevel             = "info"
-	DefaultDBEndpoint           = "postgresql://user:password@localhost:5432/ragnodb"
+	DefaultDBEndpoint           = "postgresql://user:password@localhost:5440/ragnodb?sslmode=disable"
 	DefaultHostIP               = "0.0.0.0"
-	DefaultHostPort             = 9050
+	DefaultHostPort             = 9051
 	DefaultMetricsIP            = "localhost"
-	DefaultMetricsPort          = 9070
+	DefaultMetricsPort          = 9071
 	DefaultMetricsEndpoint      = "metrics"
 	DefaultConcurrentDialers    = 150
 	DefaultConcurrentPersisters = 2
 	DefaultConnTimeout          = 30 * time.Second
 	DefaultSnapshotInterval     = 12 * time.Hour
 	DefaultIPAPIUrl             = "http://ip-api.com/json/{__ip__}?fields=status,continent,continentCode,country,countryCode,region,regionName,city,zip,lat,lon,isp,org,as,asname,mobile,proxy,hosting,query"
+	DefaultDeprecationTime      = 48 * time.Hour
 )
 
 type CrawlerRunConf struct {
@@ -36,6 +37,7 @@ type CrawlerRunConf struct {
 	ConnTimeout      time.Duration `yaml:"conn-timeout"`
 	SnapshotInterval time.Duration `yaml:"snapshot-interval"`
 	IPAPIUrl         string        `yaml:"snapshot-interval"`
+	DeprecationTime  time.Duration `yaml:"deprecation-time"`
 }
 
 func NewDefaultRun() *CrawlerRunConf {
@@ -52,6 +54,7 @@ func NewDefaultRun() *CrawlerRunConf {
 		ConnTimeout:      DefaultConnTimeout,
 		SnapshotInterval: DefaultSnapshotInterval,
 		IPAPIUrl:         DefaultIPAPIUrl,
+		DeprecationTime:  DefaultDeprecationTime,
 	}
 }
 
@@ -70,47 +73,34 @@ func (c *CrawlerRunConf) parseDurationVar(
 
 // Only considered the configuration for the Execution Layer's crawler -> RunCommand
 func (c *CrawlerRunConf) Apply(ctx *cli.Context) error {
-	if ctx.IsSet("log-level") {
-		parsedLevel, err := logrus.ParseLevel(ctx.String("log-level"))
-		if err != nil {
-			logrus.Warnf("invalid log level %s, using %s", ctx.String("log-level"), DefaultLogLevel)
-		} else {
-			c.LogLevel = parsedLevel.String()
-			logrus.SetLevel(parsedLevel)
+	config := map[string]func(flag string){
+		"log-level": func(flag string) {
+			parsedLevel, err := logrus.ParseLevel(ctx.String("log-level"))
+			if err != nil {
+				logrus.Warnf("invalid log level %s, using %s", ctx.String("log-level"), DefaultLogLevel)
+			} else {
+				c.LogLevel = parsedLevel.String()
+				logrus.SetLevel(parsedLevel)
+			}
+		},
+		"db-endpoint":       func(flag string) { c.DbEndpoint = ctx.String(flag) },
+		"ip":                func(flag string) { c.HostIP = ctx.String(flag) },
+		"port":              func(flag string) { c.HostPort = ctx.Int(flag) },
+		"metrics-ip":        func(flag string) { c.MetricsIP = ctx.String(flag) },
+		"metrics-port":      func(flag string) { c.MetricsPort = ctx.Int(flag) },
+		"metrics-endpoint":  func(flag string) { c.MetricsEndpoint = ctx.String(flag) },
+		"dialers":           func(flag string) { c.Dialers = ctx.Int(flag) },
+		"persisters":        func(flag string) { c.Persisters = ctx.Int(flag) },
+		"conn-timeout":      func(flag string) { c.ConnTimeout = c.parseDurationVar(flag, DefaultConnTimeout, ctx) },
+		"snapshot-interval": func(flag string) { c.SnapshotInterval = c.parseDurationVar(flag, DefaultSnapshotInterval, ctx) },
+		"ip-api-url":        func(flag string) { c.IPAPIUrl = ctx.String(flag) },
+		"deprecation-time":  func(flag string) { c.DeprecationTime = c.parseDurationVar(flag, DefaultDeprecationTime, ctx) },
+	}
+
+	for flag, applier := range config {
+		if ctx.IsSet(flag) {
+			applier(flag)
 		}
-	}
-	if ctx.IsSet("db-endpoint") {
-		c.DbEndpoint = ctx.String("db-endpoint")
-	}
-	if ctx.IsSet("ip") {
-		c.HostIP = ctx.String("ip")
-	}
-	if ctx.IsSet("port") {
-		c.HostPort = ctx.Int("port")
-	}
-	if ctx.IsSet("metrics-ip") {
-		c.MetricsIP = ctx.String("metrics-ip")
-	}
-	if ctx.IsSet("metrics-port") {
-		c.MetricsPort = ctx.Int("metrics-port")
-	}
-	if ctx.IsSet("metrics-endpoint") {
-		c.MetricsEndpoint = ctx.String("metrics-endpoint")
-	}
-	if ctx.IsSet("dialers") {
-		c.Dialers = ctx.Int("dialers")
-	}
-	if ctx.IsSet("persisters") {
-		c.Persisters = ctx.Int("persisters")
-	}
-	if ctx.IsSet("conn-timeout") {
-		c.ConnTimeout = c.parseDurationVar("conn-timeout", DefaultConnTimeout, ctx)
-	}
-	if ctx.IsSet("snapshot-interval") {
-		c.SnapshotInterval = c.parseDurationVar("snapshot-interval", DefaultSnapshotInterval, ctx)
-	}
-	if ctx.IsSet("ip-api-url") {
-		c.IPAPIUrl = ctx.String("ip-api-url")
 	}
 	return nil
 }

--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -77,7 +77,7 @@ func NewCrawler(ctx context.Context, conf CrawlerRunConf) (*Crawler, error) {
 		ctx:      ctx,
 		doneC:    make(chan struct{}, 1),
 		host:     host,
-		peering:  NewPeeringService(ctx, host, db, conf.Dialers, IPLocator),
+		peering:  NewPeeringService(ctx, host, db, conf.Dialers, conf.DeprecationTime, IPLocator),
 		db:       db,
 		peerDisc: discvService,
 		metrics:  prometheusMetrics,

--- a/crawler/dial_states.go
+++ b/crawler/dial_states.go
@@ -57,10 +57,11 @@ func ParseStateFromError(err string) (state DialState) {
 	case ErrorNone:
 		state = PossitiveState
 	case ErrorEOF, ErrorDisconnectRequested, ErrorDecodeRLPdisconnect,
-		ErrorBadHandshake, ErrorBadHandshake2, ErrorSnappyCorryptedInput,
-		ErrorConnectionReset, ErrorConnectionRefused, ErrorTooManyPeers:
+		ErrorBadHandshake, ErrorBadHandshake2, ErrorSnappyCorruptedInput,
+		ErrorConnectionReset, ErrorConnectionRefused, ErrorTooManyPeers,
+		ErrorNoRouteToHost, ErrorProtocolNegotiation, ErrorBadHandshakeDisconnect:
 		state = NegativeWithHopeState
-	case ErrorTimeout, ErrorUselessPeer:
+	case ErrorTimeout, ErrorIOTimeout, ErrorUselessPeer:
 		state = NegativeWithoutHopeState
 	default:
 		state = NegativeWithHopeState

--- a/crawler/errors.go
+++ b/crawler/errors.go
@@ -43,7 +43,7 @@ var KnownErrors = map[string]string{
 func ParseConnError(err error) string {
 	parsedError := ErrorUnknown
 	for cleanErr, containable := range KnownErrors {
-		if strings.ContainsAny(err.Error(), containable) {
+		if strings.Contains(err.Error(), containable) {
 			parsedError = cleanErr
 			break
 		}

--- a/crawler/errors.go
+++ b/crawler/errors.go
@@ -10,34 +10,42 @@ var (
 	ErrorNone    = "none"
 	ErrorUnknown = "unknown"
 
-	ErrorEOF                  = "eof"
-	ErrorDisconnectRequested  = "disconnect_requested"
-	ErrorDecodeRLPdisconnect  = "rlp_decode_disconnect"
-	ErrorUselessPeer          = "useless_peer"
-	ErrorBadHandshake         = "bad_handshake"
-	ErrorBadHandshake2        = "bad_handshake_code_2"
-	ErrorTimeout              = "time_out"
-	ErrorSnappyCorryptedInput = "snappy_input_corrupted"
-	ErrorSubprotocol          = "subprotocol_error"
-	ErrorConnectionRefused    = "connection_refused"
-	ErrorConnectionReset      = "connection_reset_by_peer"
-	ErrorTooManyPeers         = "too_many_peers"
+	ErrorEOF                    = "eof"
+	ErrorDisconnectRequested    = "disconnect_requested"
+	ErrorDecodeRLPdisconnect    = "rlp_decode_disconnect"
+	ErrorUselessPeer            = "useless_peer"
+	ErrorBadHandshake           = "bad_handshake"
+	ErrorBadHandshake2          = "bad_handshake_code_2"
+	ErrorTimeout                = "time_out"
+	ErrorSnappyCorruptedInput   = "snappy_input_corrupted"
+	ErrorSubprotocol            = "subprotocol_error"
+	ErrorConnectionRefused      = "connection_refused"
+	ErrorConnectionReset        = "connection_reset_by_peer"
+	ErrorTooManyPeers           = "too_many_peers"
+	ErrorIOTimeout              = "i/o_timeout"
+	ErrorNoRouteToHost          = "no_route_to_host"
+	ErrorProtocolNegotiation    = "eth_protocols_negotiation"
+	ErrorBadHandshakeDisconnect = "bad_handshake_disconnect"
 )
 
 var KnownErrors = map[string]string{
-	ErrorNone:                 "None",
-	ErrorEOF:                  "EOF",
-	ErrorDisconnectRequested:  "disconnect requested",
-	ErrorDecodeRLPdisconnect:  "rlp: expected input list for ethtest.Disconnect",
-	ErrorUselessPeer:          "useless peer",
-	ErrorBadHandshake:         "bad handshake: &ethtest.Error{err:(*errors.errorString)",
-	ErrorBadHandshake2:        "bad status handshake code: 2",
-	ErrorTimeout:              "connect: connection timed out",
-	ErrorSnappyCorryptedInput: "snappy: corrupt input",
-	ErrorSubprotocol:          "subprotocol error",
-	ErrorConnectionRefused:    "connect: connection refused",
-	ErrorConnectionReset:      "connection reset by peer",
-	ErrorTooManyPeers:         "too many peers",
+	ErrorNone:                   "None",
+	ErrorEOF:                    "EOF",
+	ErrorDisconnectRequested:    "disconnect requested",
+	ErrorDecodeRLPdisconnect:    "rlp: expected input list for ethtest.Disconnect",
+	ErrorUselessPeer:            "useless peer",
+	ErrorBadHandshake:           "bad handshake: ",
+	ErrorBadHandshake2:          "bad status handshake code: 2",
+	ErrorTimeout:                "connect: connection timed out",
+	ErrorSnappyCorruptedInput:   "snappy: corrupt input",
+	ErrorSubprotocol:            "subprotocol error",
+	ErrorConnectionRefused:      "connect: connection refused",
+	ErrorConnectionReset:        "connection reset by peer",
+	ErrorTooManyPeers:           "too many peers",
+	ErrorIOTimeout:              "i/o timeout",
+	ErrorNoRouteToHost:          "connect: no route to host",
+	ErrorProtocolNegotiation:    "eth protocols negotiation",
+	ErrorBadHandshakeDisconnect: "bad status handshake disconnect: ",
 }
 
 func ParseConnError(err error) string {

--- a/crawler/errors_test.go
+++ b/crawler/errors_test.go
@@ -40,8 +40,13 @@ func TestParseConnError(t *testing.T) {
 		},
 		{
 			name:     "Test Bad Handshake Error",
-			input:    errors.New("bad handshake: &ethtest.Error{err:(*errors.errorString)"),
+			input:    errors.New("bad handshake: "),
 			expected: ErrorBadHandshake,
+		},
+		{
+			name:     "Test Bad Handshake Disconnect Error",
+			input:    errors.New("bad status handshake disconnect: "),
+			expected: ErrorBadHandshakeDisconnect,
 		},
 		{
 			name:     "Test Bad Handshake Code 2 Error",
@@ -56,7 +61,7 @@ func TestParseConnError(t *testing.T) {
 		{
 			name:     "Test Snappy Corrupted Input Error",
 			input:    errors.New("snappy: corrupt input"),
-			expected: ErrorSnappyCorryptedInput,
+			expected: ErrorSnappyCorruptedInput,
 		},
 		{
 			name:     "Test Subprotocol Error",
@@ -87,6 +92,21 @@ func TestParseConnError(t *testing.T) {
 			name:     "Test Unknown Error",
 			input:    errors.New("something something..."),
 			expected: ErrorUnknown,
+		},
+		{
+			name:     "Test I/O Timeout Error",
+			input:    errors.New("i/o timeout"),
+			expected: ErrorIOTimeout,
+		},
+		{
+			name:     "Test No Route to Host Error",
+			input:    errors.New("connect: no route to host"),
+			expected: ErrorNoRouteToHost,
+		},
+		{
+			name:     "Test Eth Protocols Negotiation Error",
+			input:    errors.New("eth protocols negotiation"),
+			expected: ErrorProtocolNegotiation,
 		},
 	}
 

--- a/crawler/errors_test.go
+++ b/crawler/errors_test.go
@@ -1,0 +1,99 @@
+package crawler
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseConnError(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    error
+		expected string
+	}{
+		{
+			name:     "Test None Error",
+			input:    errors.New("None"),
+			expected: ErrorNone,
+		},
+		{
+			name:     "Test EOF Error",
+			input:    errors.New("EOF"),
+			expected: ErrorEOF,
+		},
+		{
+			name:     "Test Disconnect Requested Error",
+			input:    errors.New("disconnect requested"),
+			expected: ErrorDisconnectRequested,
+		},
+		{
+			name:     "Test Decode RLP Disconnect Error",
+			input:    errors.New("rlp: expected input list for ethtest.Disconnect"),
+			expected: ErrorDecodeRLPdisconnect,
+		},
+		{
+			name:     "Test Useless Peer Error",
+			input:    errors.New("useless peer"),
+			expected: ErrorUselessPeer,
+		},
+		{
+			name:     "Test Bad Handshake Error",
+			input:    errors.New("bad handshake: &ethtest.Error{err:(*errors.errorString)"),
+			expected: ErrorBadHandshake,
+		},
+		{
+			name:     "Test Bad Handshake Code 2 Error",
+			input:    errors.New("bad status handshake code: 2"),
+			expected: ErrorBadHandshake2,
+		},
+		{
+			name:     "Test Timeout Error",
+			input:    errors.New("connect: connection timed out"),
+			expected: ErrorTimeout,
+		},
+		{
+			name:     "Test Snappy Corrupted Input Error",
+			input:    errors.New("snappy: corrupt input"),
+			expected: ErrorSnappyCorryptedInput,
+		},
+		{
+			name:     "Test Subprotocol Error",
+			input:    errors.New("subprotocol error"),
+			expected: ErrorSubprotocol,
+		},
+		{
+			name:     "Test Connection Refused Error",
+			input:    errors.New("connect: connection refused"),
+			expected: ErrorConnectionRefused,
+		},
+		{
+			name:     "Test Connection Reset Error",
+			input:    errors.New("connection reset by peer"),
+			expected: ErrorConnectionReset,
+		},
+		{
+			name:     "Test Too Many Peers Error",
+			input:    errors.New("too many peers"),
+			expected: ErrorTooManyPeers,
+		},
+		{
+			name:     "Test Too Many Peers Error with longer message",
+			input:    errors.New("too many peers !?!"),
+			expected: ErrorTooManyPeers,
+		},
+		{
+			name:     "Test Unknown Error",
+			input:    errors.New("something something..."),
+			expected: ErrorUnknown,
+		},
+	}
+
+	for _, testItem := range tests {
+		t.Run(testItem.name, func(t *testing.T) {
+			result := ParseConnError(testItem.input)
+			require.Equal(t, testItem.expected, result)
+		})
+	}
+}

--- a/crawler/peering.go
+++ b/crawler/peering.go
@@ -16,7 +16,6 @@ import (
 )
 
 const (
-	DeprecationMargin = 48 * time.Hour
 	InitDelay         = 2 * time.Second
 )
 
@@ -30,6 +29,7 @@ type Peering struct {
 	orchersterDoneC chan struct{}
 	dialC           chan models.HostInfo
 	dialers         int
+	deprecationTime time.Duration
 
 	// necessary services
 	host      *Host
@@ -40,7 +40,7 @@ type Peering struct {
 
 func NewPeeringService(
 	ctx context.Context, h *Host, database *db.PostgresDBService, dialers int,
-	IPLocator *apis.IPLocator,
+	deprecationTime time.Duration, IPLocator *apis.IPLocator,
 ) *Peering {
 	return &Peering{
 		ctx:             ctx,
@@ -51,6 +51,7 @@ func NewPeeringService(
 		db:              database,
 		nodeSet:         NewNodeOrderedSet(),
 		dialers:         dialers,
+		deprecationTime: deprecationTime,
 		IPLocator:       IPLocator,
 	}
 }
@@ -168,7 +169,7 @@ func (p *Peering) Connect(hInfo models.HostInfo) {
 	// try to connect to the peer
 	connAttempt, nodeInfo, sameNetwork := p.connect(hInfo)
 	// handle the result (check if it's deprecable) and update local perception
-	p.nodeSet.UpdateNodeFromConnAttempt(hInfo.ID, &connAttempt, sameNetwork)
+	p.nodeSet.UpdateNodeFromConnAttempt(hInfo.ID, &connAttempt, sameNetwork, p.deprecationTime)
 	// persist the node with all the necessary info
 	p.db.PersistNodeInfo(connAttempt, nodeInfo, sameNetwork)
 	// If the current node's IP is public, locate IP info and persist if valid
@@ -305,7 +306,9 @@ func (s *NodeOrderedSet) RemoveNode(nodeID enode.ID) {
 }
 
 func (s *NodeOrderedSet) UpdateNodeFromConnAttempt(
-	nodeID enode.ID, connAttempt *models.ConnectionAttempt, sameNetwork bool) {
+	nodeID enode.ID, connAttempt *models.ConnectionAttempt, sameNetwork bool,
+	deprecationTime time.Duration,
+	) {
 	logEntry := logrus.WithFields(logrus.Fields{
 		"nodeID":  nodeID.String(),
 		"attempt": connAttempt.Status.String(),
@@ -335,7 +338,7 @@ func (s *NodeOrderedSet) UpdateNodeFromConnAttempt(
 		if connAttempt.Deprecable {
 			s.RemoveNode(nodeID)
 		} else {
-			node.AddNegativeDial(connAttempt.Timestamp, ParseStateFromError(connAttempt.Error))
+			node.AddNegativeDial(connAttempt.Timestamp, deprecationTime, ParseStateFromError(connAttempt.Error))
 		}
 
 	default:
@@ -462,11 +465,11 @@ func (n *QueuedNode) AddPositiveDial(baseT time.Time) {
 	n.deprecationTime = time.Time{}
 }
 
-func (n *QueuedNode) AddNegativeDial(baseT time.Time, state DialState) {
+func (n *QueuedNode) AddNegativeDial(baseT time.Time, deprecationTime time.Duration, state DialState) {
 	logrus.Trace("adding negative dial attempt to node", n.hostInfo.ID.String())
 	n.state = state
 	n.nextDialTime = baseT.Add(state.DelayFromState())
 	if n.deprecationTime.IsZero() {
-		n.deprecationTime = baseT.Add(DeprecationMargin)
+		n.deprecationTime = baseT.Add(deprecationTime)
 	}
 }

--- a/crawler/peering.go
+++ b/crawler/peering.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	DeprecationMargin = 3 * time.Hour
+	DeprecationMargin = 48 * time.Hour
 	InitDelay         = 2 * time.Second
 )
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,7 @@ services:
       --conn-timeout=${CONN_TIMEOUT}
       --metrics-endpoint=${METRICS_ENDPOINT}
       --snapshot-interval=${SNAPSHOT_INTERVAL}
+      --deprecation-time=${DEPRECATION_TIME}
     restart: unless-stopped
     depends_on:
       db:

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
-	github.com/prometheus/client_golang v1.14.0 // indirect
+	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.39.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect
@@ -75,6 +75,12 @@ require (
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
 )
 
-require github.com/lib/pq v1.10.2 // indirect
+require github.com/stretchr/testify v1.8.1
+
+require (
+	github.com/lib/pq v1.10.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)
 
 replace github.com/ethereum/go-ethereum v1.11.6 => ./go-ethereum


### PR DESCRIPTION
# Changes
- Add unit tests for `ParseConnError`
- Fix bug when parsing connection errors, which would previously be parsed at random (used `ContainsAny` instead of `Contains`)
- Added 4 new known error types (`ErrorIOTimeout`, `ErrorNoRouteToHost`, `ErrorProtocolNegotiation`, `ErrorBadHandshakeDisconnect`)
- Deprecation margin increased from 3 to 48 hours