### PR TITLE
35 fix upsert for first connected

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -2,7 +2,7 @@ DB_USER=user
 DB_PASSWORD=password
 # Use name of container (e.g. db) when using with docker compose
 DB_IP=127.0.0.0
-DB_PORT=54
+DB_PORT=5432
 DB_DATABASE=ragnodb
 
 LOG_LEVEL="trace"

--- a/.env-template
+++ b/.env-template
@@ -14,6 +14,6 @@ METRICS_IP="127.0.0.1"
 METRICS_ENDPOINT="metrics"
 METRICS_PORT=5080
 DIALERS=500
-SNAPSHOT_INTERVAL="12h"
+SNAPSHOT_INTERVAL="30m"
 IP_API_URL="http://ip-api.com/json/{__ip__}?fields=status,continent,continentCode,country,countryCode,region,regionName,city,zip,lat,lon,isp,org,as,asname,mobile,proxy,hosting,query"
 DEPRECATION_TIME="48h"

--- a/crawler/config.go
+++ b/crawler/config.go
@@ -10,7 +10,7 @@ import (
 var (
 	// crawler host related metrics
 	DefaultLogLevel             = "info"
-	DefaultDBEndpoint           = "postgresql://user:password@localhost:5440"
+	DefaultDBEndpoint           = "postgresql://user:password@localhost:5432/ragnodb"
 	DefaultHostIP               = "0.0.0.0"
 	DefaultHostPort             = 9050
 	DefaultMetricsIP            = "localhost"

--- a/crawler/config.go
+++ b/crawler/config.go
@@ -10,7 +10,7 @@ import (
 var (
 	// crawler host related metrics
 	DefaultLogLevel             = "info"
-	DefaultDBEndpoint           = "postgresql://user:password@localhost:5432/ragnodb"
+	DefaultDBEndpoint           = "postgresql://user:password@localhost:5440"
 	DefaultHostIP               = "0.0.0.0"
 	DefaultHostPort             = 9050
 	DefaultMetricsIP            = "localhost"
@@ -19,7 +19,7 @@ var (
 	DefaultConcurrentDialers    = 150
 	DefaultConcurrentPersisters = 2
 	DefaultConnTimeout          = 30 * time.Second
-	DefaultSnapshotInterval     = 12 * time.Hour
+	DefaultSnapshotInterval     = 30 * time.Minute
 	DefaultIPAPIUrl             = "http://ip-api.com/json/{__ip__}?fields=status,continent,continentCode,country,countryCode,region,regionName,city,zip,lat,lon,isp,org,as,asname,mobile,proxy,hosting,query"
 	DefaultDeprecationTime      = 48 * time.Hour
 )

--- a/db/active_peers.go
+++ b/db/active_peers.go
@@ -19,6 +19,7 @@ func (DB *PostgresDBService) getActivePeers() ([]int, error) {
 		FROM node_info
 		WHERE deprecated = 'false' AND
 		first_connected IS NOT NULL AND
+		network_id = 1 AND
 		client_name IS NOT NULL AND
 		last_connected > CURRENT_TIMESTAMP - ($1 * INTERVAL '1 DAY')
 		`,

--- a/db/node.go
+++ b/db/node.go
@@ -72,9 +72,6 @@ func (d *PostgresDBService) upsertNodeInfo(nInfo models.NodeInfo, sameNetwork bo
 	ON CONFLICT (node_id) DO UPDATE SET
 		ip = $3,
 		tcp = $4,
-		first_connected = CASE
-			WHEN excluded.first_connected IS NOT NULL THEN excluded.first_connected
-			ELSE $5 END,
 		last_connected = $6,
 		raw_user_agent = $7,
 		client_name = $8,


### PR DESCRIPTION
# Changes
- `active_peers` table only contains undeprecated nodes with `network_id` 1
- On conflict, do nothing to `first_connected`
- Change default snapshot interval from 12h to 30m
