### PR TITLE
Fix Deadlocks on node_info

### DIFF
--- a/db/ip_info.go
+++ b/db/ip_info.go
@@ -2,75 +2,12 @@ package db
 
 import (
 	"time"
-    "strings"
 
 	"github.com/jackc/pgx/v4"
 	"github.com/pkg/errors"
 
 	"github.com/cortze/ragno/models"
 )
-
-var ispCleaner = []struct {
-	substr, name string
-}{
-    {"amazon", "Amazon"},
-    {"google", "Google"},
-    {"microsoft", "Microsoft"},
-    {"oracle", "Oracle"},
-    {"at&t", "AT&T"},
-    {"vodafone", "Vodafone"},
-    {"orange", "Orange"},
-    {"china mobile", "China Mobile"},
-    {"china telecom", "China Telecom"},
-    {"alibaba", "Alibaba"},
-    {"pt comunicacoes", "PT Comunicacoes"},
-    {"swisscom", "Swisscom"},
-    {"sony", "Sony"},
-    {"telecom argentina", "Telecom Argentina"},
-    {"ovh", "OVH"},
-    {"t-mobile", "T-Mobile"},
-    {"hetzner", "Hetzner"},
-    {"digitalocean", "DigitalOcean"},
-    {"verizon", "Verizon"},
-    {"virgin media", "Virgin Media"},
-    {"hostinger", "Hostinger"},
-    {"telefonica", "Telefonica"},
-    {"contabo", "Contabo"},
-    {"mevspace", "Mevspace"},
-    {"chinanet", "Chinanet"},
-    {"kamatera", "Kamatera"},
-    {"teraswitch", "TeraSwitch"},
-    {"emirates telecommunications", "Etisalat"},
-    {"emirates integrated telecommunications", "du"},
-    {"centurylink", "CenturyLink"},
-    {"huawei", "Huawei"},
-    {"frontier communications", "Frontier Communications"},
-    {"charter communications", "Charter Communications"},
-    {"digi ", "DIGI"},
-    {"akamai", "Akamai Technologies"},
-    {"china unicom", "China Unicom"},
-    {"telus communications", "TELUS Communications"},
-    {"datacamp limited", "DataCamp"},
-    {"limestone", "Limestone Networks"},
-    {"hong kong telecommunications", "Hong Kong Telecommunications"},
-    {"velia.net", "velia.net"},
-    {"comcast", "Comcast"},
-    {"init7", "Init7"},
-    {"hivelocity", "Hivelocity"},
-    {"leaseweb", "LeaseWeb"},
-    {"fornex hosting", "Fornex Hosting"},
-    {"servers.com", "Servers.com"},
-    {"nos comunicacoes", "NOS Comunicacoes"},
-}
-
-func CleanISP(isp string) (string) {
-	for _, ispClean := range ispCleaner{
-		if strings.Contains(strings.ToLower(isp), ispClean.substr){
-			return ispClean.name
-		}
-	}
-	return isp
-}
 
 // UpsertIP attemtps to insert IP in the DB - or Updates the data info if they where already there
 func (p *PostgresDBService) UpsertIpInfo(IPInfo models.IPInfo) (query string, args []interface{}) {
@@ -130,7 +67,7 @@ func (p *PostgresDBService) UpsertIpInfo(IPInfo models.IPInfo) (query string, ar
 	args = append(args, IPInfo.Zip)
 	args = append(args, IPInfo.Lat)
 	args = append(args, IPInfo.Lon)
-	args = append(args, CleanISP(IPInfo.Isp))
+	args = append(args, IPInfo.Isp)
 	args = append(args, IPInfo.Org)
 	args = append(args, IPInfo.As)
 	args = append(args, IPInfo.AsName)

--- a/db/ip_info.go
+++ b/db/ip_info.go
@@ -2,12 +2,75 @@ package db
 
 import (
 	"time"
+    "strings"
 
 	"github.com/jackc/pgx/v4"
 	"github.com/pkg/errors"
 
 	"github.com/cortze/ragno/models"
 )
+
+var ispCleaner = []struct {
+	substr, name string
+}{
+    {"amazon", "Amazon"},
+    {"google", "Google"},
+    {"microsoft", "Microsoft"},
+    {"oracle", "Oracle"},
+    {"at&t", "AT&T"},
+    {"vodafone", "Vodafone"},
+    {"orange", "Orange"},
+    {"china mobile", "China Mobile"},
+    {"china telecom", "China Telecom"},
+    {"alibaba", "Alibaba"},
+    {"pt comunicacoes", "PT Comunicacoes"},
+    {"swisscom", "Swisscom"},
+    {"sony", "Sony"},
+    {"telecom argentina", "Telecom Argentina"},
+    {"ovh", "OVH"},
+    {"t-mobile", "T-Mobile"},
+    {"hetzner", "Hetzner"},
+    {"digitalocean", "DigitalOcean"},
+    {"verizon", "Verizon"},
+    {"virgin media", "Virgin Media"},
+    {"hostinger", "Hostinger"},
+    {"telefonica", "Telefonica"},
+    {"contabo", "Contabo"},
+    {"mevspace", "Mevspace"},
+    {"chinanet", "Chinanet"},
+    {"kamatera", "Kamatera"},
+    {"teraswitch", "TeraSwitch"},
+    {"emirates telecommunications", "Etisalat"},
+    {"emirates integrated telecommunications", "du"},
+    {"centurylink", "CenturyLink"},
+    {"huawei", "Huawei"},
+    {"frontier communications", "Frontier Communications"},
+    {"charter communications", "Charter Communications"},
+    {"digi ", "DIGI"},
+    {"akamai", "Akamai Technologies"},
+    {"china unicom", "China Unicom"},
+    {"telus communications", "TELUS Communications"},
+    {"datacamp limited", "DataCamp"},
+    {"limestone", "Limestone Networks"},
+    {"hong kong telecommunications", "Hong Kong Telecommunications"},
+    {"velia.net", "velia.net"},
+    {"comcast", "Comcast"},
+    {"init7", "Init7"},
+    {"hivelocity", "Hivelocity"},
+    {"leaseweb", "LeaseWeb"},
+    {"fornex hosting", "Fornex Hosting"},
+    {"servers.com", "Servers.com"},
+    {"nos comunicacoes", "NOS Comunicacoes"},
+}
+
+func CleanISP(isp string) (string) {
+	for _, ispClean := range ispCleaner{
+		if strings.Contains(strings.ToLower(isp), ispClean.substr){
+			return ispClean.name
+		}
+	}
+	return isp
+}
 
 // UpsertIP attemtps to insert IP in the DB - or Updates the data info if they where already there
 func (p *PostgresDBService) UpsertIpInfo(IPInfo models.IPInfo) (query string, args []interface{}) {
@@ -67,7 +130,7 @@ func (p *PostgresDBService) UpsertIpInfo(IPInfo models.IPInfo) (query string, ar
 	args = append(args, IPInfo.Zip)
 	args = append(args, IPInfo.Lat)
 	args = append(args, IPInfo.Lon)
-	args = append(args, IPInfo.Isp)
+	args = append(args, CleanISP(IPInfo.Isp))
 	args = append(args, IPInfo.Org)
 	args = append(args, IPInfo.As)
 	args = append(args, IPInfo.AsName)

--- a/db/migrations/000001_base_enr_and_node_tables.up.sql
+++ b/db/migrations/000001_base_enr_and_node_tables.up.sql
@@ -30,3 +30,12 @@ CREATE TABLE IF NOT EXISTS node_info (
      error TEXT,
      deprecated BOOL
 );
+
+CREATE TABLE IF NOT EXISTS conn_attempts (
+  id            SERIAL PRIMARY KEY,
+  node_id       TEXT NOT NULL REFERENCES node_info(node_id),
+  tried_at      TIMESTAMPTZ NOT NULL,
+  error         TEXT,
+  deprecated    BOOLEAN,
+  latency       BIGINT
+);

--- a/db/migrations/000001_base_enr_and_node_tables.up.sql
+++ b/db/migrations/000001_base_enr_and_node_tables.up.sql
@@ -30,12 +30,3 @@ CREATE TABLE IF NOT EXISTS node_info (
      error TEXT,
      deprecated BOOL
 );
-
-CREATE TABLE IF NOT EXISTS conn_attempts (
-  id            SERIAL PRIMARY KEY,
-  node_id       TEXT NOT NULL REFERENCES node_info(node_id),
-  tried_at      TIMESTAMPTZ NOT NULL,
-  error         TEXT,
-  deprecated    BOOLEAN,
-  latency       BIGINT
-);

--- a/db/migrations/000007_add_conn_attempts.down.sql
+++ b/db/migrations/000007_add_conn_attempts.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS conn_attempts;

--- a/db/migrations/000007_add_conn_attempts.up.sql
+++ b/db/migrations/000007_add_conn_attempts.up.sql
@@ -1,0 +1,9 @@
+-- Create table to store every connection attempt
+CREATE TABLE IF NOT EXISTS conn_attempts (
+  id            SERIAL PRIMARY KEY,
+  node_id       TEXT NOT NULL REFERENCES node_info(node_id),
+  tried_at      TIMESTAMPTZ NOT NULL,
+  error         TEXT,
+  deprecated    BOOLEAN,
+  latency       BIGINT
+);

--- a/db/node.go
+++ b/db/node.go
@@ -12,12 +12,10 @@ import (
 
 func (d *PostgresDBService) insertConnectionAttempt(attempt models.ConnectionAttempt) (query string, args []interface{}) {
 	query = `
-	UPDATE node_info SET
-		last_tried=$2,
-		error=$3,
-		deprecated=$4,
-		latency=$5
-	WHERE node_id=$1;
+		INSERT INTO conn_attempts
+		(node_id, tried_at, error, deprecated, latency)
+		VALUES
+		($1, $2, $3, $4, $5);
 	`
 	args = append(args, attempt.ID.String())
 	args = append(args, attempt.Timestamp)


### PR DESCRIPTION
### Problem

Concurrent writes were deadlocking between `insertConnectionAttempt` and `upsertNodeInfo`.

### Changes

- Add a dedicated table `conn_attempts` to persist each attempt.
- Replace the `UPDATE node_info` in `insertConnectionAttempt` with an `INSERT INTO conn_attempts`

### Explanation

The previous deadlock came from two different lock orders on the same row in `node_info`. Moving attempt writes to a separate table removes that contention path. The upsert on `node_info` remains unchanged.